### PR TITLE
Make environment argument take precedence over global environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,12 +17,12 @@ class ServerlessPlugin {
   }
 
   getEnvironment(options) {
-    if (process.env.NODE_ENV) {
-      return process.env.NODE_ENV
-    }
-
     if (options.env) {
       return options.env
+    }
+    
+    if (process.env.NODE_ENV) {
+      return process.env.NODE_ENV
     }
 
     return 'development'


### PR DESCRIPTION
I think this behaviour is super weird. Took me about an hour of cursing to find out why I was unable to deploy anything.
Setting a global `NODE_ENV` is pretty common (and what I've had for years), but that should never take precedence over explicit arguments. 

I'd expect this thing to take the `staging` `.env`:

```sh
NODE_ENV=development npx serverless deploy --stage staging --env staging
```