### PR TITLE
Allow environment configuration via stage parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ class ServerlessPlugin {
       return options.env
     }
     
+    if (options.stage) {
+      return options.stage
+    }
+    
     if (process.env.NODE_ENV) {
       return process.env.NODE_ENV
     }


### PR DESCRIPTION
This allows you to leave out `--env` in favour of the Serverless native `--stage`.